### PR TITLE
Add New ATC Objects (CHKC/CHKO) for ATC Check Variants

### DIFF
--- a/abap/zknsf_ci_category.chkc.json
+++ b/abap/zknsf_ci_category.chkc.json
@@ -1,0 +1,7 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Kernseife Open-Source",
+    "originalLanguage": "en"
+  }
+}

--- a/abap/zknsf_ci_kernseife.chko.json
+++ b/abap/zknsf_ci_kernseife.chko.json
@@ -1,0 +1,20 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Kernseife: Usage of APIs",
+    "originalLanguage": "en"
+  },
+  "category": "ZKNSF_CI_CATEGORY",
+  "implementingClass": "ZKNSF_CL_API_USAGE",
+  "checkType": "remoteEnabled",
+  "parameters": [
+    {
+      "name": "releasedAPIDataSource",
+      "description": "Released API Data Source"
+    },
+    {
+      "name": "classicAPIDataSource",
+      "description": "Classic API Data Source"
+    }
+  ]
+}


### PR DESCRIPTION
To enable this ATC check to be used with the new ATC Check Variants (CHKV) (available only in ADT 😉), an ATC Check Category (CHKC) and ATC Check (CHKO) object are needed. 

![image](https://github.com/user-attachments/assets/83f551fb-91e8-4f1a-80ad-aa076d01b5d0)
