### PR TITLE
Remove `commit_hash` from unit tests

### DIFF
--- a/abap/zknsf_cl_provider_with_cache.clas.testclasses.abap
+++ b/abap/zknsf_cl_provider_with_cache.clas.testclasses.abap
@@ -119,14 +119,12 @@ class ltcl_data_provider_cache implementation.
                                  url         = 'github.com/file.json'
                                  created     = '20241015101523'
                                  data_type   = cl_ycm_cc_cache_write_api=>co_data_type_classic
-                                 commit_hash = '55'
                                  )
                                  (
                                  file_Id     = '11'
                                  url         = 'github.com/file2.json'
                                  created     = '20241015101523'
                                  data_type   = cl_ycm_cc_cache_write_api=>co_data_type_classic
-                                 commit_hash = '66'
                                  ) ).
     environment->insert_test_data( i_data = td_classic_apis_h ).
 
@@ -222,14 +220,12 @@ class ltcl_data_provider_cache implementation.
                                  created     = '20241015101523'
                                  url         = 'github.com/file.json'
                                  data_type   = cl_ycm_cc_cache_write_api=>co_data_type_release
-                                 commit_hash = '55'
                                  )
                                  (
                                  file_Id     = '31'
                                  created     = '20241015101523'
                                  url         = 'github.com/file.json'
                                  data_type   = cl_ycm_cc_cache_write_api=>co_data_type_release
-                                 commit_hash = '66'
                                  ) ).
     environment->insert_test_data( i_data = td_release_apis_h ).
 


### PR DESCRIPTION
We removed the field `commit_hash` starting with S/4 HANA 2025 as it was replaced by field `etag` in a previous version of the SAP Note. To prevent syntax errors (and as it is unnecessary in this test) I would suggest removing it.

_(What are you even testing here, just copying our tests doesn't help much 😆)_
