### PR TITLE
Fix Function Group Changes

### DIFF
--- a/abap/zknsf_cl_api_usage.clas.abap
+++ b/abap/zknsf_cl_api_usage.clas.abap
@@ -316,7 +316,7 @@ CLASS ZKNSF_CL_API_USAGE IMPLEMENTATION.
     ENDIF.
 
     " This is only supported in none-remote setups!
-    IF language_version = if_abap_language_version=>gc_version-standard_source_code
+    IF code = if_abap_language_version=>gc_version-standard_source_code
     AND zknsf_cl_key_user_util=>get_instance( )->is_key_user_generated( object_type = object_type object_name = object_name ) = abap_true.
       code = if_abap_language_version=>gc_version-key_user.
     ENDIF.

--- a/abap/zknsf_cl_provider_with_cache.clas.abap
+++ b/abap/zknsf_cl_provider_with_cache.clas.abap
@@ -1,17 +1,17 @@
-class ZKNSF_CL_PROVIDER_WITH_CACHE definition
-  public
-  final
-  create public .
+CLASS zknsf_cl_provider_with_cache DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  interfaces IF_YCM_CC_PROVIDER_CLASSIC_API .
+    INTERFACES if_ycm_cc_provider_classic_api .
 
-  methods CONSTRUCTOR
-    raising
-      CX_YCM_CC_PROVIDER_ERROR .
+    METHODS constructor
+      RAISING
+        cx_ycm_cc_provider_error .
   PROTECTED SECTION.
-private section.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -30,10 +30,12 @@ CLASS ZKNSF_CL_PROVIDER_WITH_CACHE IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    SELECT * FROM zknsf_apis_c_scsr FOR ALL ENTRIES IN @apis WHERE  tadir_object   = @apis-trobjtype
-                                                              AND   tadir_obj_name = @apis-sobj_name
+    DATA api_with_successor_info TYPE STANDARD TABLE OF zknsf_apis_c_scsr.
+
+    SELECT * FROM zknsf_apis_c_scsr FOR ALL ENTRIES IN @apis WHERE (
+       ( tadir_object   = @apis-trobjtype AND tadir_obj_name = @apis-sobj_name ) OR ( tadir_object = 'FUGR' AND object_type = 'FUNC' ) )
                                                               AND   object_type    = @apis-object_type
-                                                              AND   object_key     = @apis-sub_key INTO TABLE @DATA(api_with_successor_info).
+                                                              AND   object_key     = @apis-sub_key INTO TABLE @api_with_successor_info.
 
     LOOP AT api_with_successor_info ASSIGNING FIELD-SYMBOL(<classic_api_bundle>) GROUP BY ( tadir_object   = <classic_api_bundle>-tadir_object
                                                                                             tadir_obj_name = <classic_api_bundle>-tadir_obj_name

--- a/abap/zknsf_i_atc_findings.ddls.asddls
+++ b/abap/zknsf_i_atc_findings.ddls.asddls
@@ -11,6 +11,7 @@ define view entity ZKNSF_I_ATC_FINDINGS
   as select from    satc_ac_resulth      as h
     inner join      satc_ac_fnd_v        as fnd_v                on h.check_run_ix = fnd_v.check_run_ix
     inner join      satc_ac_itm          as itm                  on itm.item_id = fnd_v.item_id   // item
+    and ( itm.status = '1' or itm.status = '2' )
     inner join      satc_ac_fnd          as fnd                  on fnd.item_id = fnd_v.item_id   // finding
     inner join      satc_ac_obj          as obj                  on obj.object_ix = fnd.object_ix // object
     inner join      satc_ac_osy          as osy // package and contact person


### PR DESCRIPTION
As documented in[ an issue in the official Cloudification Repository](https://github.com/SAP/abap-atc-cr-cv-s4hc/issues/90), the Classic API uses the latest Function Group for Function Modules.
This leads to a wrong detection of Function Modules which are moved between Function Groups in newer releases (e.g. RPY_TRANSACTION_INSERT).
We added a fix, which ignores the Function Group for the Classification of Function Modules, as they are anyway unique by Function Module Name.

Fixed an Issue in the Finding export to only return the latest/active Findings (this issue reported the same finding again in the BTP app, even if the classification "fixed" it)

Fixed the reporting of Key-User generated objects as actual Language version "Key-User"

