### PR TITLE
fix: use UPSERT for DevelopmentObjectUsages to avoid duplicates

### DIFF
--- a/btp/srv/features/developmentObject-feature.ts
+++ b/btp/srv/features/developmentObject-feature.ts
@@ -664,7 +664,7 @@ const importFindingsBTPBySystem = async (
     }
 
     if (usageInsert.length > 0) {
-      await INSERT.into('kernseife.db.DevelopmentObjectUsages').entries(
+      await UPSERT.into('kernseife.db.DevelopmentObjectUsages').entries(
         usageInsert
       );
       if (tx) {


### PR DESCRIPTION
Replaces INSERT with UPSERT when importing usage data to prevent duplicate key errors on reimport.
Fixes #82 