### PR TITLE
allow development-manager to run Extensions actions

### DIFF
--- a/btp/app/manage-extension/annotations.cds
+++ b/btp/app/manage-extension/annotations.cds
@@ -51,28 +51,28 @@ annotate service.Extensions with @(
     UI.Identification                : [
         {
             $Type        : 'UI.DataFieldForAction',
-            Action       : 'AdminService.clearDevelopmentObjectList',
+            Action       : 'DevelopmentService.clearDevelopmentObjectList',
             Label        : '{i18n>clearDevelopmentObjectList}',
             Determining  : true,
             ![@UI.Hidden]: {$edmJson: {$Path: '/DevelopmentService.EntityContainer/FeatureControl/isNotManager'}},
         },
         {
             $Type        : 'UI.DataFieldForAction',
-            Action       : 'AdminService.addUnassignedDevelopmentObjects',
+            Action       : 'DevelopmentService.addUnassignedDevelopmentObjects',
             Label        : '{i18n>addUnassignedDevelopmentObjects}',
             Determining  : true,
             ![@UI.Hidden]: {$edmJson: {$Path: '/DevelopmentService.EntityContainer/FeatureControl/isNotManager'}},
         },
         {
             $Type        : 'UI.DataFieldForAction',
-            Action       : 'AdminService.addDevelopmentObjectsByDevClass',
+            Action       : 'DevelopmentService.addDevelopmentObjectsByDevClass',
             Label        : '{i18n>addDevelopmentObjectsByDevClass}',
             Determining  : true,
             ![@UI.Hidden]: {$edmJson: {$Path: '/DevelopmentService.EntityContainer/FeatureControl/isNotManager'}},
         },
         {
             $Type        : 'UI.DataFieldForAction',
-            Action       : 'AdminService.addDevelopmentObject',
+            Action       : 'DevelopmentService.addDevelopmentObject',
             Label        : '{i18n>addDevelopmentObject}',
             Determining  : true,
             ![@UI.Hidden]: {$edmJson: {$Path: '/DevelopmentService.EntityContainer/FeatureControl/isNotManager'}},

--- a/btp/srv/development-service.cds
+++ b/btp/srv/development-service.cds
@@ -86,7 +86,7 @@ service DevelopmentService @(requires: ['development-viewer']) {
     entity Extensions                              @(restrict: [
         {grant: 'READ'},
         {
-            grant: 'WRITE',
+            grant: '*',
             to   : 'development-manager'
         }
     ])                                       as projection on db.Extensions


### PR DESCRIPTION
Fixes #85 .

`btp/srv/development-service.cds` — `Extensions` `@restrict`:

```diff
-    {grant: 'WRITE', to: 'development-manager'}
+    {grant: '*',     to: 'development-manager'}

'WRITE' didn't cover bound-action execution, so all four actions on Extensions returned 403 for every user. Verified on a live deployment.

Drive-by: btp/app/manage-extension/annotations.cds — four UI.DataFieldForAction entries aligned from AdminService.* to DevelopmentService.*.