### PR TITLE
fix: missing closing parenthesis in subquery

### DIFF
--- a/btp/srv/features/developmentObject-feature.ts
+++ b/btp/srv/features/developmentObject-feature.ts
@@ -127,7 +127,7 @@ export const calculateScores = async () => {
     'UPDATE kernseife_db_DEVELOPMENTOBJECTS as d SET score = IFNULL(' +
       '(SELECT sum(IFNULL(f.total,0)) AS sum_score ' +
       'FROM kernseife_db_DEVELOPMENTOBJECTFINDINGS as f ' +
-      'WHERE f.objectType = d.objectType AND f.objectName = d.objectName AND f.devClass = d.devClass AND f.systemId = d.systemId ' +
+      'WHERE f.objectType = d.objectType AND f.objectName = d.objectName AND f.devClass = d.devClass AND f.systemId = d.systemId)' +
       ',0)'
   );
 


### PR DESCRIPTION
### Fix SQL Syntax Error in calculateScores

There is a minor issue based on closed Issue https://github.com/SAP/project-kernseife/issues/75 and Pull Request https://github.com/SAP/project-kernseife/pull/74.

With the commit of https://github.com/SAP/project-kernseife/pull/74/commits/9f41296cbfce078a4eb34f86befa4aeadc89e567 the closing parenthesis of line #121 was removed. This causes again to an SQL error when the backend action `recalculateAllScores` is invoked.

In BTP a dialog is shown with error message "Internal Server Error".

### Error log 
``
"msg": "500 - [SqlError: sql syntax error: incorrect syntax near ",": line 1 col 279 (at pos 279)] { code: '257', sqlState: 'HY000', level: 1, position: 0, query: 'UPDATE kernseife_db_DEVELOPMENTOBJECTS as d SET score = IFNULL((SELECT sum(IFNULL(f.total,0)) AS sum_score FROM kernseife_db_DEVELOPMENTOBJECTFINDINGS as f WHERE f.objectType = d.objectType AND f.objectName = d.objectName AND f.devClass = d.devClass AND f.systemId = d.systemId ,0) }"
``

### Solution
Adding the closing parenthesis

### Before
```typescript
await db.run(
  'UPDATE kernseife_db_DEVELOPMENTOBJECTS as d SET score = IFNULL(' +
  '(SELECT sum(IFNULL(f.total,0)) AS sum_score ' +
  'FROM kernseife_db_DEVELOPMENTOBJECTFINDINGS as f ' +
  'WHERE f.objectType = d.objectType AND ...' + ❌ // missing
  ',0)'
);
```

### After
```typescript
await db.run(
  'UPDATE kernseife_db_DEVELOPMENTOBJECTS as d SET score = IFNULL(' +
  '(SELECT sum(IFNULL(f.total,0)) AS sum_score ' +
  'FROM kernseife_db_DEVELOPMENTOBJECTFINDINGS as f ' +
  'WHERE f.objectType = d.objectType AND ...)' + ✅ // fixed
  ',0)'
);
```